### PR TITLE
Add windows support

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -1,1 +1,1 @@
-load_keys.sh
+source $(dirname "${BASH_SOURCE[0]}")/load_keys.sh

--- a/hooks/load_keys.sh
+++ b/hooks/load_keys.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 SSH_AGENT="ssh-agent"
 SSH_ADD="ssh-add"
 # If we're on windows, we want to use the builtin openssh utilities, not mingw ones
-if [[ "$(uname)" == *MINGW64* ]]; then
+if [[ "$(uname 2>/dev/null)" == *MINGW64* ]]; then
     SSH_AGENT="/C/Windows/System32/OpenSSH/ssh-agent"
     SSH_ADD="/C/Windows/System32/OpenSSH/ssh-add"
     powershell -noprofile -command "Start-Service ssh-agent"

--- a/hooks/load_keys.sh
+++ b/hooks/load_keys.sh
@@ -2,10 +2,20 @@
 
 set -eou pipefail
 
-# Start up ssh-agent if we don't already have a valid SSH_AUTH_SOCK
-if [ ! -S "${SSH_AUTH_SOCK:-}" ]; then
-    echo "No pre-existing ssh-agent found, starting one up..."
-    eval "$(ssh-agent -s 2>/dev/null)"
+SSH_AGENT="ssh-agent"
+SSH_ADD="ssh-add"
+# If we're on windows, we want to use the builtin openssh utilities, not mingw ones
+if [[ "$(uname)" == *MINGW64* ]]; then
+    SSH_AGENT="/C/Windows/System32/OpenSSH/ssh-agent"
+    SSH_ADD="/C/Windows/System32/OpenSSH/ssh-add"
+    powershell -noprofile -command "Start-Service ssh-agent"
+    export GIT_SSH="C:\\Windows\\System32\\OpenSSH\\ssh.exe"
+else
+    # Start up ssh-agent if we don't already have a valid SSH_AUTH_SOCK
+    if [ ! -S "${SSH_AUTH_SOCK:-}" ]; then
+        echo "No pre-existing ssh-agent found, starting one up..."
+        eval "$("${SSH_AGENT}" -s 2>/dev/null)"
+    fi
 fi
 
 # Load keyfiles off of disk
@@ -13,7 +23,7 @@ IDX=0
 while [[ -v "BUILDKITE_PLUGIN_SSH_AGENT_KEYFILES_${IDX}" ]]; do
     VARNAME="BUILDKITE_PLUGIN_SSH_AGENT_KEYFILES_${IDX}"
     if [[ -f "${!VARNAME}" ]]; then
-        cat "${!VARNAME}" | ssh-add -
+        cat "${!VARNAME}" | "${SSH_ADD}" -
     else
         echo "Skipping ${!VARNAME} as it doesn't exist (yet)"
     fi
@@ -32,8 +42,8 @@ while [[ -v "BUILDKITE_PLUGIN_SSH_AGENT_KEYVARS_${IDX}" ]]; do
     # Then we dereference _again_ to get the actual keyfile contents.
     # We first try feeding it directly into `ssh-add`, and if that doesn't
     # work, we base64-decode it, as that's a common encoding we use.
-    if ! ssh-add - <<< "${!VARNAME}" 2>/dev/null; then
-        if ! base64 -d <<< "${!VARNAME}" | ssh-add -; then
+    if ! "${SSH_ADD}" - <<< "${!VARNAME}" 2>/dev/null; then
+        if ! base64 -d <<< "${!VARNAME}" | "${SSH_ADD}" -; then
             echo "Unable to add SSH key stored in ${VARNAME}!" >&2
             
             if [[ "${BUILDKITE_PLUGIN_SSH_AGENT_DEBUG:-false}" == "true" ]]; then
@@ -47,4 +57,4 @@ while [[ -v "BUILDKITE_PLUGIN_SSH_AGENT_KEYVARS_${IDX}" ]]; do
 done
 
 # List all loaded SSH keys
-ssh-add -l || true
+"${SSH_ADD}" -l || true

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,1 +1,1 @@
-load_keys.sh
+source $(dirname "${BASH_SOURCE[0]}")/load_keys.sh

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-if [[ "$(uname)" == *MINGW64* ]]; then
+if [[ "$(uname 2>/dev/null)" == *MINGW64* ]]; then
     # Tell the windows service to forget everything, and then die
     /C/Windows/System32/OpenSSH/ssh-agent -D
     powershell -noprofile -command "Stop-Service ssh-agent"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,5 +2,11 @@
 
 set -eou pipefail
 
-# Kill ssh-agent, to clean up added ssh keys
-ssh-agent -k
+if [[ "$(uname)" == *MINGW64* ]]; then
+    # Tell the windows service to forget everything, and then die
+    /C/Windows/System32/OpenSSH/ssh-agent -D
+    powershell -noprofile -command "Stop-Service ssh-agent"
+else
+    # Kill ssh-agent, to clean up added ssh keys
+    ssh-agent -k
+fi


### PR DESCRIPTION
We make use of the builtin windows OpenSSH client; dodging any git-bash
ssh agents that may or may not exist.