### PR TITLE
Treat cygwin OSTYPE as Windows in load_keys/pre-exit

### DIFF
--- a/hooks/load_keys.sh
+++ b/hooks/load_keys.sh
@@ -4,8 +4,10 @@ set -eou pipefail
 
 SSH_AGENT="ssh-agent"
 SSH_ADD="ssh-add"
-# If we're on windows, we want to use the builtin openssh utilities, not mingw ones
-if [[ "${OSTYPE}" == "msys"* ]]; then
+# If we're on windows, we want to use the builtin openssh utilities, not mingw ones.
+# Git-for-Windows bash reports OSTYPE as either "msys" or "cygwin" depending on the
+# Git version (e.g. 2.54.0 reports "cygwin"), so match both.
+if [[ "${OSTYPE}" == "msys"* || "${OSTYPE}" == "cygwin"* ]]; then
     SSH_AGENT="/C/Windows/System32/OpenSSH/ssh-agent"
     SSH_ADD="/C/Windows/System32/OpenSSH/ssh-add"
     echo "Starting ssh-agent service, if not already started..."

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-if [[ "${OSTYPE}" == "msys"* ]]; then
+if [[ "${OSTYPE}" == "msys"* || "${OSTYPE}" == "cygwin"* ]]; then
     # Tell the windows service to forget everything, and then die
     /C/Windows/System32/OpenSSH/ssh-agent -D
     powershell -noprofile -command "Stop-Service ssh-agent"


### PR DESCRIPTION
Git-for-Windows bash reports OSTYPE as "msys" or "cygwin" depending on the Git version (2.54.0 reports "cygwin"). The Windows branch was gated on "msys"* only, so on a "cygwin" agent it was skipped: the ssh-agent *service* was never started and the key was loaded into a mingw unix-socket agent that the native checkout ssh.exe (core.sshCommand = System32\OpenSSH\ssh.exe) cannot reach via its named pipe -> git clone failed with "Permission denied (publickey)". Match both OSTYPE values so the native OpenSSH path runs. Verified live on a win2k22 worker (OSTYPE=cygwin).